### PR TITLE
Fix document table-creating function

### DIFF
--- a/eda-report-basics.ipynb
+++ b/eda-report-basics.ipynb
@@ -24,7 +24,7 @@
      "text": [
       "Bivariate analysis: 100%|███████████████████████████████████| 6/6 numeric pairs.\n",
       "Univariate analysis: 100%|███████████████████████████████████| 5/5 features.\n",
-      "[INFO 01:31:15.594] Done. Results saved as 'iris-report.docx'\n"
+      "[INFO 08:25:12.361] Done. Results saved as 'iris-report.docx'\n"
      ]
     },
     {
@@ -33,7 +33,7 @@
        "<a href='iris-report.docx' target='_blank'>iris-report.docx</a><br>"
       ],
       "text/plain": [
-       "/home/tim/Projects/eda-report/iris-report.docx"
+       "/home/jovyan/iris-report.docx"
       ]
      },
      "execution_count": 1,
@@ -69,24 +69,21 @@
        "\t  Summary Statistics (Numeric features)\n",
        "\t  -------------------------------------\n",
        "              count    mean     std  min  25%   50%  75%  max  skewness  \\\n",
-       "              count    mean     std  min  25%   50%  75%  max  skewness   \n",
-       "petal_length  150.0   3.758  1.7653  1.0  1.6  4.35  5.1  6.9   -0.2749   \n",
-       "petal_width   150.0  1.1993  0.7622  0.1  0.3   1.3  1.8  2.5    -0.103   \n",
-       "sepal_length  150.0  5.8433  0.8281  4.3  5.1   5.8  6.4  7.9    0.3149   \n",
-       "sepal_width   150.0  3.0573  0.4359  2.0  2.8   3.0  3.3  4.4     0.319   \n",
+       "sepal_length  150.0  5.8433  0.8281  4.3  5.1  5.80  6.4  7.9    0.3149   \n",
+       "sepal_width   150.0  3.0573  0.4359  2.0  2.8  3.00  3.3  4.4    0.3190   \n",
+       "petal_length  150.0  3.7580  1.7653  1.0  1.6  4.35  5.1  6.9   -0.2749   \n",
+       "petal_width   150.0  1.1993  0.7622  0.1  0.3  1.30  1.8  2.5   -0.1030   \n",
        "\n",
        "              kurtosis  \n",
-       "              kurtosis  \n",
-       "petal_length   -1.4021  \n",
-       "petal_width    -1.3406  \n",
        "sepal_length   -0.5521  \n",
        "sepal_width     0.2282  \n",
+       "petal_length   -1.4021  \n",
+       "petal_width    -1.3406  \n",
        "\t\t\t  ***\n",
        "\t  Summary Statistics (Categorical features)\n",
        "\t  -----------------------------------------\n",
-       "         count  unique     top  freq  relative freq\n",
-       "         count  unique     top  freq  relative freq\n",
-       "species    150       3  setosa    50         33.33%\n",
+       "        count unique     top freq relative freq\n",
+       "species   150      3  setosa   50        33.33%\n",
        "\t\t\t  ***\n",
        "\t  Bivariate Analysis (Correlation)\n",
        "\t  --------------------------------\n",
@@ -165,9 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -235,7 +230,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/eda_report/document.py
+++ b/eda_report/document.py
@@ -357,10 +357,12 @@ class ReportDocument(ReportContent):
             Flags whether the first row is a header, by default False.
         """
         if header:
-            data.loc["", :] = data.columns
-            # Sort the index in ascending order, to ensure that column names
-            # end up as the first row.
-            data.sort_index(inplace=True)
+            # Add a row of column labels
+            data_with_header = data.copy()
+            data_with_header.loc["", :] = data.columns
+
+            # Ensure that column labels are in the first row
+            data = data_with_header.sort_index()
 
         table = self.document.add_table(
             rows=len(data),


### PR DESCRIPTION
Use a copy of the provided data to generate tables. Add column labels to this copy if a table header is desired. 

This prevents unintentional modification of the data supplied to the table creating function, particularly the duplication of column labels:

![image](https://user-images.githubusercontent.com/53743348/133976972-f23c7543-38be-47e7-8aa0-78d067ab96e1.png)
