### PR TITLE
Use StringDtype for text & mixed data. Fixes #16.

### DIFF
--- a/eda_report/univariate.py
+++ b/eda_report/univariate.py
@@ -82,11 +82,13 @@ class Variable:
 
         elif is_datetime64_any_dtype(self.data):
             return "datetime"
-        elif (self.data.nunique() / self.data.shape[0]) <= (1 / 3):
-            # If 1/3 or less of the values are unique, use categorical
-            self.data = self.data.astype("category")
+
         else:
-            self.data = self.data.astype("object")
+            self.data = self.data.astype("string")
+            if (self.data.nunique() / self.data.shape[0]) <= (1 / 3):
+                # If 1/3 or less of the values are unique, use categorical
+                self.data = self.data.astype("category")
+
         return "categorical"
 
     def _get_missing_values_info(self) -> Optional[str]:

--- a/tests/test_univariate_analysis.py
+++ b/tests/test_univariate_analysis.py
@@ -11,7 +11,7 @@ from pandas.api.types import (
     is_categorical_dtype,
     is_datetime64_any_dtype,
     is_numeric_dtype,
-    is_object_dtype,
+    is_string_dtype,
 )
 
 
@@ -49,7 +49,7 @@ class TestVariableProperties:
         assert isinstance(self.unnamed_variable.data, Series)
 
         assert is_numeric_dtype(self.variable.data)
-        assert is_object_dtype(self.unnamed_variable.data)
+        assert is_string_dtype(self.unnamed_variable.data)
 
         assert self.variable.var_type == "numeric"
         assert self.unnamed_variable.var_type == "categorical"
@@ -88,7 +88,7 @@ class TestCategoricalStats:
         assert isinstance(self.majority_unique, CategoricalStats)
         assert isinstance(self.majority_repeating, CategoricalStats)
 
-        assert is_object_dtype(self.majority_unique.variable.data)
+        assert is_string_dtype(self.majority_unique.variable.data)
         assert self.majority_unique.variable.var_type == "categorical"
 
         assert is_categorical_dtype(self.majority_repeating.variable.data)


### PR DESCRIPTION
`object` dtype causes errors when sorting mixed numeric+text data.